### PR TITLE
Setting limit throws IllegalFormatConversionException

### DIFF
--- a/src/main/java/fr/dudie/nominatim/client/request/NominatimSearchRequest.java
+++ b/src/main/java/fr/dudie/nominatim/client/request/NominatimSearchRequest.java
@@ -85,7 +85,7 @@ public class NominatimSearchRequest extends NominatimRequest {
     private List<String> excludePlaceIds;
 
     /** Limit the number of returned results. */
-    @QueryParameter("limit=%d")
+    @QueryParameter("limit=%s")
     private Integer limit;
 
     /** Choose output geometry format. */


### PR DESCRIPTION
At the moment, setting the limit parameter throws the following exception:
```
java.util.IllegalFormatConversionException: d != java.lang.String
	at java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4045)
	at java.util.Formatter$FormatSpecifier.printInteger(Formatter.java:2748)
	at java.util.Formatter$FormatSpecifier.print(Formatter.java:2702)
	at java.util.Formatter.format(Formatter.java:2488)
	at java.util.Formatter.format(Formatter.java:2423)
	at java.lang.String.format(String.java:2834)
	at fr.dudie.nominatim.client.request.QueryParameterAnnotationHandler.process(QueryParameterAnnotationHandler.java:97)
	at fr.dudie.nominatim.client.request.NominatimRequest.getQueryString(NominatimRequest.java:47)
	at fr.dudie.nominatim.client.JsonNominatimClient.search(JsonNominatimClient.java:188)
```
The issue is that the following line of code ```String paramValue = serialize(paramMetadata, fieldValue, f.getName());``` in ```QueryParameterAnnotationHandler.process(final Object o) (line 88)``` method converts the value of limit parameter from Integer to String. 

However when you try to format the value as it is done in ```String.format(Locale.US, paramFormat, paramValue)``` in ```QueryParameterAnnotationHandler.process(final Object o) (line 97)```, it uses the %d formatter for limit specified in ```QueryParmeter```. For instance if you set the limit to 3, the following code is executed ```String.format(Locale.US, "%d", "3")``` which results in the above exception.